### PR TITLE
Add Dev Container

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,22 @@
+// For format details, see https://aka.ms/devcontainer.json. For config options, see the
+// README at: https://github.com/devcontainers/templates/tree/main/src/ruby
+{
+	"name": "Ruby",
+	// Or use a Dockerfile or Docker Compose file. More info: https://containers.dev/guide/dockerfile
+	"image": "mcr.microsoft.com/devcontainers/ruby:3.2",
+
+	// Features to add to the dev container. More info: https://containers.dev/features.
+	// "features": {},
+
+	// Use 'forwardPorts' to make a list of ports inside the container available locally.
+	// "forwardPorts": [],
+
+	// Use 'postCreateCommand' to run commands after the container is created.
+	"postCreateCommand": "gem install bundler -v 2.1.4"
+
+	// Configure tool-specific properties.
+	// "customizations": {},
+
+	// Uncomment to connect as root instead. More info: https://aka.ms/dev-containers-non-root.
+	// "remoteUser": "root"
+}

--- a/Gemfile
+++ b/Gemfile
@@ -5,3 +5,5 @@ require 'rbconfig'
 if RbConfig::CONFIG['target_os'] =~ /mswin|mingw|cygwin/i
    gem 'wdm', '>= 0.1.0'
 end
+
+gem "webrick", "~> 1.8"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -216,6 +216,8 @@ GEM
     nokogiri (1.16.2)
       mini_portile2 (~> 2.8.2)
       racc (~> 1.4)
+    nokogiri (1.16.2-x64-mingw32)
+      racc (~> 1.4)
     octokit (4.25.1)
       faraday (>= 1, < 3)
       sawyer (~> 0.9)
@@ -252,6 +254,7 @@ GEM
     unf_ext (0.0.8.2)
     unf_ext (0.0.8.2-x64-mingw32)
     unicode-display_width (1.8.0)
+    webrick (1.8.1)
 
 PLATFORMS
   ruby
@@ -259,6 +262,7 @@ PLATFORMS
 
 DEPENDENCIES
   github-pages
+  webrick (~> 1.8)
 
 BUNDLED WITH
    2.1.4


### PR DESCRIPTION
Add Dev Container support to simplify initial setup.

I'm using Ruby 3.2 as 3.3 is throwing an error ` undefined method `[]' for nil (NoMethodError)` when I try to run `bundle exec jekyll serve`. I also had to add webrick to GemFile to prevent [an error](https://github.com/github/pages-gem/issues/752) when using Ruby 3.x. The Ruby LSP is also throwing an error but I don't think there's actually much ruby in this project so I might look at what's causing that error later (unless someone else can sort it out).

I'm far from a ruby expert so let me know if any of the versions, etc are wrong and I'll fix them. I have to admit this took longer then I expected to get running.