### PR TITLE
Remove twitter link from main page

### DIFF
--- a/index.html
+++ b/index.html
@@ -83,10 +83,6 @@ title: Home
 <div style="text-align: center;">
 	<script src="https://www.openhub.net/p/175/widgets/project_basic_stats.js" type="text/javascript"></script>
 </div>
-<hr />
-<div style="text-align: center;">
-	<p><a href="http://www.twitter.com/NHibernate"><img alt="Follow NHibernate on Twitter" src="https://twitter-badges.s3.amazonaws.com/follow_us-b.png" /></a></p>
-</div>
 
 <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.2.1/jquery.min.js" integrity="sha256-hwg4gsxgFZhOsEEamdOYGBf13FyQuiTwlAQgxVSNgt4=" crossorigin="anonymous"></script>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/jcarousel/0.3.5/jquery.jcarousel.min.js" integrity="sha256-IeZIlqw8y4qMafw/TaWbqktXVww/sS9N8BkaPe3bEsQ=" crossorigin="anonymous"></script>


### PR DESCRIPTION
Twitter is now known as X. So we can either update the logo or remove the link. As no tweets have been posted in the last 10 years we should probably just remove the link.